### PR TITLE
Pass the database connection into OdooGrammar for Laravel 12 compatibility

### DIFF
--- a/src/Database/OdooConnector.php
+++ b/src/Database/OdooConnector.php
@@ -18,7 +18,7 @@ class OdooConnector
         $this->config = $config;
 
         $connection = new OdooConnection($pdo, $config['database'], '', $config);
-        $connection->setQueryGrammar(new OdooGrammar);
+        $connection->setQueryGrammar(new OdooGrammar($connection));
         return $connection;
     }
 }

--- a/src/Database/OdooGrammar.php
+++ b/src/Database/OdooGrammar.php
@@ -12,7 +12,9 @@ class OdooGrammar extends BaseGrammar
 {
     public function __construct(Connection $connection)
     {
-        parent::__construct($connection);
+        if (version_compare(app()->version(), '12.0', '>=')) {
+            parent::__construct($connection);
+        }
     }
 
     public function compileSelect(Builder $query)

--- a/src/Database/OdooGrammar.php
+++ b/src/Database/OdooGrammar.php
@@ -4,11 +4,17 @@ declare(strict_types=1);
 
 namespace Sefirosweb\LaravelOdooConnector\Database;
 
+use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\Grammars\Grammar as BaseGrammar;
 
 class OdooGrammar extends BaseGrammar
 {
+    public function __construct(Connection $connection)
+    {
+        parent::__construct($connection);
+    }
+
     public function compileSelect(Builder $query)
     {
         // $oldSql = parent::compileSelect($query);


### PR DESCRIPTION
**What changed**

* Added a `__construct(Connection $connection)` to `OdooGrammar`, forwarding the connection to the parent.
* Updated `OdooConnector::connect()` to call

  ```php
  $connection->setQueryGrammar(
      new OdooGrammar($connection)
  );
  ```

  instead of instantiating `OdooGrammar` with no arguments.

**Why**
Laravel 12 introduced a required `Connection` parameter on `Illuminate\Database\Query\Grammars\Grammar::__construct()`. Without this change, creating a new grammar with no arguments throws an `ArgumentCountError`.

**How to test**

1. Install the package in a Laravel 12 project.
2. Run typical query operations (`select`, `insert`, `update`, `delete`) through the connector.
3. Confirm no constructor errors occur and expected JSON-RPC payloads are returned.


Disclaimer
I don’t know what I’m doing; I did it using ChatGPT.